### PR TITLE
Set apiLevel correctly in file headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Then you can just run `make`.
 
 ## History
 
+2018-10-03: v2.1
+ * FIX: luna now defaults to an older file header version unless the input file is a bitmap
+
 2016-12-28: v2.0
  * NEW: No OpenSSL library dependency anymore, just use the relevant DES code.
  * FIX: Fix crash when parsing deeply nested XML documents

--- a/minizip-1.1/zip.h
+++ b/minizip-1.1/zip.h
@@ -194,7 +194,9 @@ extern int ZEXPORT zipOpenNewFileInZip2 OF((zipFile file,
                                             const char* comment,
                                             int method,
                                             int level,
-                                            int raw));
+                                            int raw,
+                                            int tiapimajor,
+                                            int tiapiminor));
 
 
 extern int ZEXPORT zipOpenNewFileInZip2_64 OF((zipFile file,
@@ -295,7 +297,9 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 OF((zipFile file,
                                             uLong crcForCrypting,
                                             uLong versionMadeBy,
                                             uLong flagBase,
-                                            int zip64
+                                            int zip64,
+                                            int tiapimajor,
+                                            int tiapiminor
                                             ));
 /*
   Same than zipOpenNewFileInZip4, except


### PR DESCRIPTION
Scans input files for platform.apiLevel and if major is defined as 2 ("2.0", '2.0', "2.3" etc) sets appropriate LOCALHEADERMAGIC2 within minizip. If apiLevel isn't defined or something else/unsupported, it defaults to 1 for compatibility with older calcs. Parameters are now passed into minizip to help support adding later major API versions as/when they become a thing.
For input on stdin, the original default/behavior of using apiLevel 2 is retained (needs a separate re-write of various parts of luna to deal with this nicely).