### PR TITLE
Add support for Python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Luna 2.1
 ========
 
-Luna is a portable command-line converter of Lua programs to TNS TI-Nspire documents, compatible with OS 3.0.2 and later.
+Luna is a portable command-line converter of Lua and Python programs to TNS TI-Nspire documents, compatible with OS 3.0.2 and later.
 
 It can also be used to convert any TI-Nspire problems in XML format to TNS documents.
 
@@ -10,6 +10,7 @@ It can also be used to convert any TI-Nspire problems in XML format to TNS docum
 * Lua program conversion:    `luna INFILE.lua OUTFILE.tns`
 * Problem conversion:        `luna Problem1.xml OUTFILE.tns`
 * Multiple files:            `luna Document.xml Problem1.xml [Problem2.xml...] OUTFILE.tns`
+* Python conversion:         `luna INFILE.py OUTFILE.tns`
 
 If the input is `-`, it reads the file from the standard input.  
 Make sure to encode your Lua or Problem file in UTF-8 if it contains special characters. You can also pack arbitrary files like images into the TNS.

--- a/luna.c
+++ b/luna.c
@@ -587,7 +587,7 @@ int add_python_xml_to_tns(const char *python_path, const char *tnsfile_path, uns
 
 	// Filename goes sandwiched between the header and footer
 	char xmlc_buf[(sizeof(py_header) - 1) + 240 + (sizeof(py_footer) - 1)];
-	sprintf(xmlc_buf, "%s%s%s", py_header, filename, py_footer);
+	snprintf(xmlc_buf, sizeof(xmlc_buf), "%s%s%s", py_header, filename, py_footer);
 
 	size_t total_size = (sizeof(py_header) - 1) + filename_len + (sizeof(py_footer) - 1);
 	return add_compressed_xml_to_tns(tnsfile_path, "Problem1.xml", xmlc_buf, total_size, tiversion);

--- a/luna.c
+++ b/luna.c
@@ -586,16 +586,11 @@ int add_python_xml_to_tns(const char *python_path, const char *tnsfile_path, uns
 	}
 
 	// Filename goes sandwiched between the header and footer
-	size_t py_header_size = sizeof(py_header) - 1;
-	size_t py_footer_size = sizeof(py_footer) - 1;
-	size_t total_size = py_header_size + filename_len + py_footer_size;
-	uint8_t xmlc_buf[(sizeof(py_header) - 1) + 240 + (sizeof(py_footer - 1))];
+	char xmlc_buf[(sizeof(py_header) - 1) + 240 + (sizeof(py_footer - 1))];
+	sprintf(xmlc_buf, "%s%s%s", py_header, filename, py_footer);
 
-	memcpy(xmlc_buf, py_header, py_header_size);
-	memcpy(xmlc_buf + py_header_size, filename, filename_len);
-	memcpy(xmlc_buf + py_header_size + filename_len, py_footer, py_footer_size);
-	int ret = add_compressed_xml_to_tns(tnsfile_path, "Problem1.xml", xmlc_buf, total_size, tiversion);
-	return ret;
+	size_t total_size = (sizeof(py_header) - 1) + filename_len + (sizeof(py_footer) - 1);
+	return add_compressed_xml_to_tns(tnsfile_path, "Problem1.xml", xmlc_buf, total_size, tiversion);
 }
 
 int main(int argc, char *argv[]) {

--- a/luna.c
+++ b/luna.c
@@ -586,7 +586,7 @@ int add_python_xml_to_tns(const char *python_path, const char *tnsfile_path, uns
 	}
 
 	// Filename goes sandwiched between the header and footer
-	char xmlc_buf[(sizeof(py_header) - 1) + 240 + (sizeof(py_footer - 1))];
+	char xmlc_buf[(sizeof(py_header) - 1) + 240 + (sizeof(py_footer) - 1)];
 	sprintf(xmlc_buf, "%s%s%s", py_header, filename, py_footer);
 
 	size_t total_size = (sizeof(py_header) - 1) + filename_len + (sizeof(py_footer) - 1);

--- a/luna.c
+++ b/luna.c
@@ -287,7 +287,7 @@ invalid_problem:
 
 // ext must start with "."
 int has_ext(const char *filepath, const char *ext) {
-	return strlen(filepath) >= 5 && !strcasecmp(ext, filepath + strlen(filepath) - 4);
+	return strlen(filepath) > strlen(ext) && !strcasecmp(ext, filepath + strlen(filepath) - strlen(ext));
 }
 
 /* Returns the output buffer, NULL on error. Fills obuf_size.
@@ -479,7 +479,7 @@ void close_tns(const char *outfile_path) {
 }
 
 // returns the deflated size
-long deflate_compressed_xml(void *def_buf, size_t def_size, void *xmlc_buf, size_t xmlc_buf_size) {
+long deflate_compressed_xml(void *def_buf, size_t def_size, const void *xmlc_buf, size_t xmlc_buf_size) {
 	z_stream zstream;
 	zstream.next_in = (Bytef*)xmlc_buf;
 	zstream.next_out = (Bytef*)def_buf;
@@ -524,52 +524,89 @@ int add_default_document_to_tns(const char *tnsfile_path, unsigned tiversion) {
 	return add_processed_file_to_tns("Document.xml", default_processed_document_xml, sizeof(default_processed_document_xml) - 1, tnsfile_path, tiversion);
 }
 
-int add_infile_to_tns(const char *infile_path, const char *tnsfile_path, unsigned tiversion) {
-	size_t xmlc_buf_size;
-	const char *filename = NULL;
-	void *xmlc_buf = read_file_and_xml_compress(infile_path, &xmlc_buf_size, &filename);
-	if (!xmlc_buf)
-		return 1;
-
-	/* As expected by zlib */
-	size_t def_size = (size_t) (xmlc_buf_size + (xmlc_buf_size * 0.1) + 12);
+int add_compressed_xml_to_tns(const char *tnsfile_path, const char *filename, const void *xmlc_buf, size_t xmlc_buf_size, unsigned tiversion) {
 	static const char tien_crypted_header[] =
 		"\x0F\xCE\xD8\xD2\x81\x06\x86\x5B\x99\xDD\xA2\x3D\xD9\xE9\x4B\xD4\x31\xBB\x50\xB6"
 		"\x4D\xB3\x29\x24\x70\x60\x49\x38\x1C\x30\xF8\x99\x00\x4B\x92\x64\xE4\x58\xE6\xBC";
+
+	/* As expected by zlib */
+	size_t def_size = (size_t) (xmlc_buf_size + (xmlc_buf_size * 0.1) + 12);
 	size_t header_size = sizeof(tien_crypted_header) - 1;
 	uint8_t *header_and_deflated_buf = malloc(def_size + header_size);
 	if (!header_and_deflated_buf) {
 		puts("can't malloc header_and_deflated_buf");
-add_infile_err:
+add_compressed_xml_err:
 		free(header_and_deflated_buf);
 		return 1;
 	}
-	if (has_ext(filename, ".xml")) { // Only .xml files are encrypted
-		uint8_t *def_buf = header_and_deflated_buf + header_size;
-		long deflated_size = deflate_compressed_xml(def_buf, def_size, xmlc_buf, xmlc_buf_size);
-		free(xmlc_buf);
-		if (doccrypt(def_buf, deflated_size))
-			goto add_infile_err;
-		memcpy(header_and_deflated_buf, tien_crypted_header, header_size);
-		if (add_processed_file_to_tns(filename, header_and_deflated_buf, header_size + deflated_size, tnsfile_path, tiversion))
-			goto add_infile_err;
-	}
-	else { // don't crypt, don't deflate: will be deflated by minizip
-		if (add_processed_file_to_tns(filename, xmlc_buf, xmlc_buf_size, tnsfile_path, tiversion))
-			goto add_infile_err;
-	}
+
+	uint8_t *def_buf = header_and_deflated_buf + header_size;
+	long deflated_size = deflate_compressed_xml(def_buf, def_size, xmlc_buf, xmlc_buf_size);
+	if (doccrypt(def_buf, deflated_size))
+		goto add_compressed_xml_err;
+	memcpy(header_and_deflated_buf, tien_crypted_header, header_size);
+	if (add_processed_file_to_tns(filename, header_and_deflated_buf, header_size + deflated_size, tnsfile_path, tiversion))
+		goto add_compressed_xml_err;
 	free(header_and_deflated_buf);
 	return 0;
+}
+
+int add_infile_to_tns(const char *infile_path, const char *tnsfile_path, unsigned tiversion) {
+	size_t xmlc_buf_size;
+	const char *filename = NULL;
+	void *xmlc_buf = read_file_and_xml_compress(infile_path, &xmlc_buf_size, &filename);
+	int ret;
+	if (!xmlc_buf)
+		return 1;
+
+	if (has_ext(filename, ".xml")) // Only .xml files are encrypted
+		ret = add_compressed_xml_to_tns(tnsfile_path, filename, xmlc_buf, xmlc_buf_size, tiversion);
+	else // don't crypt, don't deflate: will be deflated by minizip
+		ret = add_processed_file_to_tns(filename, xmlc_buf, xmlc_buf_size, tnsfile_path, tiversion);
+	free(xmlc_buf);
+	return ret;
+}
+
+// Add XML that refers to the Python script. The Python script itself is added separately.
+int add_python_xml_to_tns(const char *python_path, const char *tnsfile_path, unsigned tiversion) {
+	static const char py_header[] =
+		"TIXC0100-1.0?><prob xmlns=\"urn:TI.Problem\" ver=\"1.0\" pbname=\"\">"
+		"<sym>\x0E\x01<card clay=\"0\" h1=\"10000\" h2=\"10000\" w1=\"10000\" "
+		"w2=\"10000\"><isDummyCard>0\x0E\x03<flag>0\x0E\x04<wdgt xmlns:py=\"urn:"
+		"TI.PythonEditor\" type=\"TI.PythonEditor\" ver=\"1.0\"><py:data><py:name>";
+	static const char py_footer[] =
+		"\x0E\x07<py:dirf>-10000000\x0E\x08\x0E\x06<py:mFlags>1024\x0E\x09"
+		"<py:value>10\x0E\x0A\x0E\x05\x0E\x02\x0E\x00";
+	const char *filename = gnu_basename(python_path);
+
+	// Filename goes sandwiched between the header and footer
+	size_t py_header_size = sizeof(py_header) - 1;
+	size_t filename_len = strlen(filename);
+	size_t py_footer_size = sizeof(py_footer) - 1;
+	size_t total_size = py_header_size + filename_len + py_footer_size;
+	uint8_t *xmlc_buf = malloc(total_size);
+	if (!xmlc_buf) {
+		puts("can't malloc xmlc_buf");
+		return 1;
+	}
+	memcpy(xmlc_buf, py_header, py_header_size);
+	memcpy(xmlc_buf + py_header_size, filename, filename_len);
+	memcpy(xmlc_buf + py_header_size + filename_len, py_footer, py_footer_size);
+	int ret = add_compressed_xml_to_tns(tnsfile_path, "Problem1.xml", xmlc_buf, total_size, tiversion);
+	free(xmlc_buf);
+	return ret;
 }
 
 int main(int argc, char *argv[]) {
 	if (argc < 3) {
 		puts("Luna v" LUNA_VER " usage:\n"
 				 "  luna [INFILE.lua|-] [OUTFILE.tns]\n"
+				 "  luna [INFILE.py]* [OUTFILE.tns]\n"
 				 "  luna [Problem1.xml|Document.xml|ABCD.BMP]* [OUTFILE.tns]\n"
-				 "Converts a Lua script or XML problems/documents/resources to a TNS document.\n"
+				 "Converts a Lua script, Python scripts, or XML problems/documents/resources to a TNS document.\n"
 				 "If the input file '-', reads it as Lua from the standard input.\n"
-				 "A default Document.xml will be generated if not specified.\n"
+				 "For Python, the first script will be the one that shows when the TNS document is opened.\n"
+				 "A default Document.xml will be generated if not specified."
 		);
 		return 0;
 	}
@@ -603,6 +640,8 @@ int main(int argc, char *argv[]) {
 
 	// Then add all the other files
 	int is_converting_lua = 0;
+	int added_python_xml = 0;
+	int ret;
 	for (int i = 1; i <= argc - 2; i++) { // infiles: the args except the last one
 		if (!strcmp("Document.xml", gnu_basename(argv[i])))
 			continue;
@@ -614,7 +653,12 @@ int main(int argc, char *argv[]) {
 			}
 			is_converting_lua = 1;
 		}
-		int ret = add_infile_to_tns(argv[i], outfile_path, tiversion);
+		if (!added_python_xml && has_ext(argv[i], ".py")) { // Add XML for just the first Python file
+			ret = add_python_xml_to_tns(argv[i], outfile_path, tiversion);
+			if (ret) return ret;
+			added_python_xml = 1;
+		}
+		ret = add_infile_to_tns(argv[i], outfile_path, tiversion);
 		if (ret) return ret;
 	}
 

--- a/luna.c
+++ b/luna.c
@@ -577,23 +577,24 @@ int add_python_xml_to_tns(const char *python_path, const char *tnsfile_path, uns
 	static const char py_footer[] =
 		"\x0E\x07<py:dirf>-10000000\x0E\x08\x0E\x06<py:mFlags>1024\x0E\x09"
 		"<py:value>10\x0E\x0A\x0E\x05\x0E\x02\x0E\x00";
+
 	const char *filename = gnu_basename(python_path);
+	size_t filename_len = strlen(filename);
+	if (filename_len > 240) {
+		puts("Python script filenames limited to 240 characters");
+		return 1;
+	}
 
 	// Filename goes sandwiched between the header and footer
 	size_t py_header_size = sizeof(py_header) - 1;
-	size_t filename_len = strlen(filename);
 	size_t py_footer_size = sizeof(py_footer) - 1;
 	size_t total_size = py_header_size + filename_len + py_footer_size;
-	uint8_t *xmlc_buf = malloc(total_size);
-	if (!xmlc_buf) {
-		puts("can't malloc xmlc_buf");
-		return 1;
-	}
+	uint8_t xmlc_buf[(sizeof(py_header) - 1) + 240 + (sizeof(py_footer - 1))];
+
 	memcpy(xmlc_buf, py_header, py_header_size);
 	memcpy(xmlc_buf + py_header_size, filename, filename_len);
 	memcpy(xmlc_buf + py_header_size + filename_len, py_footer, py_footer_size);
 	int ret = add_compressed_xml_to_tns(tnsfile_path, "Problem1.xml", xmlc_buf, total_size, tiversion);
-	free(xmlc_buf);
 	return ret;
 }
 


### PR DESCRIPTION
I've added support for Python scripts. You can add multiple Python files. The first one specified will be the one that shows up when the TNS document is opened.

Should I add some code to validate the filename? I believe the part before the .py extension cannot exceed 237 characters, and must be a valid Python identifier (only alphanumeric/underscore characters, can't start with a digit, can't be a reserved word).